### PR TITLE
Add Selenium to Helm chart

### DIFF
--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -94,6 +94,18 @@ spec:
             - name: secret-volume
               mountPath: /n8n-secret
                 {{- end }}
+        - name: selenium_chrome
+          image: selenium/standalone-chrome:129.0
+          ports:
+            - containerPort: 4444
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: selenium-env
+          volumeMounts:
+            - name: selenium-env
+              mountPath: /etc/selenium-env
+              subPath: .env
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -123,3 +135,6 @@ spec:
               - key: "secret.json"
                 path: "secret.json"
         {{- end }}
+        - name: selenium-env
+          configMap:
+            name: selenium-env

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -329,3 +329,11 @@ redis:
       enabled: true
       existingClaim: ""
       size: 2Gi
+
+selenium:
+  image: selenium/standalone-chrome:129.0
+  container_name: selenium_chrome
+  ports:
+    - "4444:4444"
+  env_file: []
+  networks: []


### PR DESCRIPTION
Add selenium configuration to Helm charts for n8n.

* **values.yaml**
  - Add a new section for `selenium` configuration.
  - Set the default image to `selenium/standalone-chrome:129.0`.
  - Add default port mapping for `4444:4444`.
  - Add an option to specify `env_file`.
  - Add an option to specify `networks`.

* **deployment.yaml**
  - Add a new container for `selenium` in the deployment spec.
  - Set the image to `selenium/standalone-chrome:129.0`.
  - Set the container name to `selenium_chrome`.
  - Map ports `4444:4444`.
  - Add environment variables from `.env` file.
  - Add the container to the `custom_network` network.

