### PR TITLE
Fix Selenium environment ConfigMap not found issue

### DIFF
--- a/charts/n8n/templates/configmap.selenium-env.yaml
+++ b/charts/n8n/templates/configmap.selenium-env.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: selenium-env
+  labels:
+    app: selenium
+data:
+  .env: |
+    SE_OPTS=-host 0.0.0.0
+    SCREEN_WIDTH=1920
+    SCREEN_HEIGHT=1080
+    SCREEN_DEPTH=24
+    DISPLAY=:99.0
+    START_XVFB=false


### PR DESCRIPTION
Add a new `ConfigMap` for `selenium-env`.

* Create a `ConfigMap` named `selenium-env` with necessary environment variables for Selenium
  * Includes variables such as `SE_OPTS`, `SCREEN_WIDTH`, `SCREEN_HEIGHT`, `SCREEN_DEPTH`, `DISPLAY`, and `START_XVFB`

